### PR TITLE
resource page with tags and unconnected UI for similar resources

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -1,9 +1,10 @@
 from flask import Blueprint, request
 from elasticsearch import Elasticsearch
+import certifi
 
 
 api = Blueprint('api', __name__,)
-es = Elasticsearch(['https://search-princeton-gerrymandering-tdoxp3nyeow6asnjm3rufdjf7y.us-east-1.es.amazonaws.com/'])
+es = Elasticsearch(['https://search-princeton-gerrymandering-tdoxp3nyeow6asnjm3rufdjf7y.us-east-1.es.amazonaws.com/'], use_ssl=True, ca_certs=certifi.where())
 
 
 @api.route("/search", methods = ["GET", "POST"])
@@ -12,8 +13,6 @@ def api_index():
     and_filters = []
     and_not_filters = []
     or_filters = []
-
-    # print(req)
 
     for filter in req['filters']:
         if req['isOr']:
@@ -29,7 +28,7 @@ def api_index():
                     }
                 }
                 or_filters.append(new_filter)
-            elif filter['filter'] == "contains_not": 
+            elif filter['filter'] == "contains_not":
                 new_filter = {
                     "bool": {
                         "must_not": {
@@ -74,5 +73,18 @@ def api_index():
         "from": req['pageSize'] * (req['page'] - 1)
     }
     print(query)
+    res = es.search(index="pgp", body=query)
+    return res
+
+
+@api.route("/resource/<string:id>", methods=["GET"])
+def resource(id):
+    query = {
+        "query": {
+            "match": {
+                "_id": id
+            }
+        }
+    }
     res = es.search(index="pgp", body=query)
     return res

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -5,3 +5,4 @@ Jinja2==2.11.1
 MarkupSafe==1.1.1
 Werkzeug==1.0.0
 Flask-CORS==3.0.8
+elasticsearch==7.6.0

--- a/client/App.tsx
+++ b/client/App.tsx
@@ -3,13 +3,15 @@ import {BrowserRouter as Router, Switch, Route, BrowserRouter} from 'react-route
 
 import Home from "./pages/Home";
 import PageNotFound from "./pages/PageNotFound";
+import Resource from "./pages/Resource";
 
 const App : React.FC = () => {
     return (
         <BrowserRouter>
             <Switch>
-                <Route path = "/" exact component = { Home }></Route>
-                <Route path = "/" component = { PageNotFound }></Route>
+                <Route path = "/" exact component = { Home } />
+                <Route path = "/resource/:id" component = { Resource } />
+                <Route path = "/" component = { PageNotFound } />
             </Switch>
         </BrowserRouter>
     )

--- a/client/App.tsx
+++ b/client/App.tsx
@@ -10,7 +10,7 @@ const App : React.FC = () => {
         <BrowserRouter>
             <Switch>
                 <Route path = "/" exact component = { Home } />
-                <Route path = "/resource/:id" component = { Resource } />
+                <Route path = "/resource/:id" exact component = { Resource } />
                 <Route path = "/" component = { PageNotFound } />
             </Switch>
         </BrowserRouter>

--- a/client/components/FilterModal.tsx
+++ b/client/components/FilterModal.tsx
@@ -48,28 +48,19 @@ const FilterModal: React.FC<FilterModalProps> = ({show, onClose, updateFilters, 
       setFilters(tempFilters)
     };
 
-    const filterList = filters.length == 1
-    ? (<FilterRow
-      key={filters[0].id}
-      id={filters[0].id}
-      deleteRow={deleteFilterRow}
-      updateRow={updateFilterRow}
-      index={0}
-      updateIsOr={updateIsOr}
-      isOr={isOr}
-      oneRow
-      />)
-    : filters.map((filter, index) => (
-      <FilterRow
-        key={filter.id}
-        id={filter.id}
-        deleteRow={deleteFilterRow}
-        updateRow={updateFilterRow}
-        index={index}
-        updateIsOr={updateIsOr}
-        isOr={isOr}
-        />
-    ));
+    const filterList = filters.map(
+      (filter, index) => (
+        <FilterRow
+          key={filter.id}
+          id={filter.id}
+          deleteRow={deleteFilterRow}
+          updateRow={updateFilterRow}
+          index={index}
+          updateIsOr={updateIsOr}
+          isOr={isOr}
+          />
+        )
+      );
 
     const handleOk = (e: React.MouseEvent<HTMLElement, MouseEvent>) => {
       updateFilters(filters);

--- a/client/components/FilterRow.tsx
+++ b/client/components/FilterRow.tsx
@@ -18,11 +18,10 @@ interface FilterRowProps {
     updateRow: (index: number, attribute: string, input:string) => void;
     updateIsOr: (or: boolean) => void;
     isOr: boolean;
-    oneRow?: boolean;
 };
 
 
-const FilterRow: React.FC<FilterRowProps> = ({ id, index, deleteRow, updateRow, updateIsOr, isOr, oneRow=false }: FilterRowProps) => {
+const FilterRow: React.FC<FilterRowProps> = ({ id, index, deleteRow, updateRow, updateIsOr, isOr }: FilterRowProps) => {
     const [attribute, setAttribute] = useState("");
     const [filter, setFilter] = useState("");
     const [value, setValue] = useState("");
@@ -44,14 +43,9 @@ const FilterRow: React.FC<FilterRowProps> = ({ id, index, deleteRow, updateRow, 
 
     const renderAndOr = () => {
       if (index == 0) {
-        if (oneRow) {
-          return null;
-        }
-        else {
-          return (
-            <div style={{ width: 80 }}></div>
-          );
-        }
+        return (
+          <div style={{ width: 80 }}></div>
+        );
       }
       else if (index == 1) {
         const defaultValue = isOr ? "or" : "and";

--- a/client/components/SearchResultsItem.tsx
+++ b/client/components/SearchResultsItem.tsx
@@ -59,7 +59,7 @@ const SearchResultsItem: React.FC<SearchResultsItemProps> = ({ item }: SearchRes
       >
         <List.Item.Meta
           avatar={<Avatar size={64} style={{ textAlign: "center" }} shape="square" icon={avatarIcon} />}
-          title={<a href={item.file}>{item.name}</a>}
+          title={<a href={`resource/${item.id}`}>{item.name}</a>}
           description={tagList}
         />
       </List.Item>

--- a/client/components/SearchResultsList.tsx
+++ b/client/components/SearchResultsList.tsx
@@ -39,7 +39,7 @@ const SearchResultsList: React.FC<SearchResultsListProps> = ({ results = [], sho
             <SearchResultsItem item={item}/>
           )}
         />
-        { resultsLoaded && 
+        { resultsLoaded &&
           <Pagination
             current={page}
             onShowSizeChange = {onPageChange}
@@ -47,7 +47,7 @@ const SearchResultsList: React.FC<SearchResultsListProps> = ({ results = [], sho
             pageSize = {pageSize}
             pageSizeOptions = {['5', '10', '20', '50']}
             style = {{ marginTop: "10px"}}
-            total = {totalResults} 
+            total = {totalResults}
             showSizeChanger
           />
         }

--- a/client/components/SimilarCarousel.tsx
+++ b/client/components/SimilarCarousel.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import ReactDOM from 'react-dom'
+import { Carousel, Button } from 'antd';
+import SimilarCarouselItem from "../components/SimilarCarouselItem";
+import '../css/SimilarCarousel.css';
+import { LeftOutlined, RightOutlined } from '@ant-design/icons';
+
+interface Tags {
+    [propName: string]: string[];
+}
+
+interface Result {
+    id: string;
+    file: string;
+    name: string;
+    tags: Tags;
+    text: string;
+    type: string;
+}
+
+const SimilarCarousel: React.FC = () => {
+
+    const listData : Result[] = [];
+    for (let i = 0; i < 11; i++) {
+      listData.push({
+        id: i.toString(),
+        file: 'test-data/2002 Districts 2010.xlsx',
+        name: "2002 Districts 2010.xlsx",
+        tags: {
+          "locations": ["Arizona", "Bushwick", "California"],
+          "orgs": ["RNC", "GOP", "DNC"],
+          "groups": ["Latinos", "Asians"],
+          "time": ["2002", "2020"]
+        },
+        text: "Ant Design, a design language for background applications, is refined by Ant UED Team.",
+        type: "xlsx"
+      });
+    }
+
+    function NextArrow(props:any) {
+      const { className, style, onClick } = props;
+      return (
+        <div
+          className={className}
+          style={{ ...style }}
+          onClick={onClick}
+        >
+        <Button type="primary" icon={<RightOutlined />} size="large" />
+        </div>
+      );
+    }
+
+    function PrevArrow(props:any) {
+      const { className, style, onClick } = props;
+      return (
+        <div
+          className={className}
+          style={{ ...style}}
+          onClick={onClick}
+        >
+        <Button type="primary" icon={<LeftOutlined />} size="large" />
+        </div>
+      );
+    }
+
+    const settings = {
+      dots: false,
+      infinite: false,
+      slidesToShow: 3,
+      slidesToScroll: 1,
+      nextArrow: <NextArrow />,
+      prevArrow: <PrevArrow />,
+      arrows: true
+    };
+
+    const resources = listData.map((resource, index) => (
+        <SimilarCarouselItem key={index} resource={resource} />)
+    );
+
+    return (
+      <Carousel {...settings}>
+        {resources}
+      </Carousel>
+    );
+}
+
+export default SimilarCarousel

--- a/client/components/SimilarCarouselItem.tsx
+++ b/client/components/SimilarCarouselItem.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import ReactDOM from 'react-dom'
+import { Carousel, Card, Avatar } from 'antd';
+import SearchResultsIcon from "../components/SearchResultsIcon";
+
+interface Tags {
+    [propName: string]: string[];
+}
+
+interface Result {
+    id: string;
+    file: string;
+    name: string;
+    tags: Tags;
+    text: string;
+    type: string;
+}
+
+interface SimilarCarouselItemProps {
+    resource: Result
+};
+
+const SimilarCarouselItem: React.FC<SimilarCarouselItemProps> = ({ resource }) => {
+
+    const avatarIcon = <SearchResultsIcon filetype={resource.type} />;
+
+    return (
+      <div>
+        <Card>
+          <Card.Meta
+            avatar={<Avatar size={64} style={{ textAlign: "center" }} shape="square" icon={avatarIcon} />}
+            title={resource.name}
+            description="This is the description"
+          />
+        </Card>
+      </div>
+    );
+}
+
+export default SimilarCarouselItem

--- a/client/components/SimilarCarouselItem.tsx
+++ b/client/components/SimilarCarouselItem.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import ReactDOM from 'react-dom'
+import ReactDOM from 'react-dom';
+import Link from "react-router";
 import { Carousel, Card, Avatar } from 'antd';
 import SearchResultsIcon from "../components/SearchResultsIcon";
 
@@ -29,7 +30,7 @@ const SimilarCarouselItem: React.FC<SimilarCarouselItemProps> = ({ resource }) =
         <Card>
           <Card.Meta
             avatar={<Avatar size={64} style={{ textAlign: "center" }} shape="square" icon={avatarIcon} />}
-            title={resource.name}
+            title={<a href={`${resource.id}`}>{resource.name}</a>}
             description="This is the description"
           />
         </Card>

--- a/client/css/FilterRow.css
+++ b/client/css/FilterRow.css
@@ -1,3 +1,6 @@
 .ant-space-item:nth-last-child(2) {
   width: 100%;
 }
+.ant-space-item #one_row {
+  width: 100%;
+}

--- a/client/css/FilterRow.css
+++ b/client/css/FilterRow.css
@@ -1,6 +1,3 @@
 .ant-space-item:nth-last-child(2) {
   width: 100%;
 }
-.ant-space-item #one_row {
-  width: 100%;
-}

--- a/client/css/SearchResultsItem.css
+++ b/client/css/SearchResultsItem.css
@@ -2,6 +2,8 @@
   background: #fff !important;
   margin-right: 0px;
   margin-left: -25.5px;
+  margin-top: 6px;
+  margin-bottom: 6px;
 }
 
 .ant-tag {

--- a/client/css/SimilarCarousel.css
+++ b/client/css/SimilarCarousel.css
@@ -1,0 +1,34 @@
+.ant-carousel .slick-slide {
+  text-align: center;
+  overflow: hidden;
+}
+
+.slick-slider {
+  margin-left: 40px;
+  margin-right: 40px;
+}
+
+.ant-carousel .slick-slide .ant-card {
+  padding-left: 4px;
+  padding-right: 4px;
+  margin-left: 8px;
+  margin-right: 8px;
+}
+
+.ant-carousel .slick-next {
+  right: -40px;
+}
+
+.ant-carousel .slick-prev {
+  left: -40px;
+}
+
+.ant-carousel .slick-prev, .ant-carousel .slick-next {
+  margin-top: -20px;
+}
+
+
+.slick-arrow {
+  width: 40px !important;
+  height: 40px !important;
+}

--- a/client/dist/index.html
+++ b/client/dist/index.html
@@ -26,6 +26,6 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <script src = "static/main-bundle.js"></script>
+    <script src = "/static/main-bundle.js"></script>
   </body>
 </html>

--- a/client/pages/Home.tsx
+++ b/client/pages/Home.tsx
@@ -74,7 +74,7 @@ const Home: React.FC = () => {
     const search = (values : any, page_ : number, pageSize_ : number) => {
         setLoaded(false);
         setShowResults(true);
-        axios.post<PostQuery>("http://localhost:5000/api/search", {
+        axios.post<PostQuery>("/api/search", {
             query,
             filters,
             isOr,

--- a/client/pages/Home.tsx
+++ b/client/pages/Home.tsx
@@ -50,7 +50,7 @@ const Home: React.FC = () => {
     const [loaded, setLoaded] = useState(false);
     const [results, setResults] = useState<Result[]>([]);
 
-    const [totalResults, setTotalResults] = useState(0); 
+    const [totalResults, setTotalResults] = useState(0);
     const [pageSize, setPageSize] = useState(5);
     const [page, setPage] = useState(1)
 
@@ -97,7 +97,7 @@ const Home: React.FC = () => {
                     let tagList : string[] = document._source.tags[tag];
                     let tagSet : Set<string> = new Set<string>(tagList);
                     tagList = [...tagSet];
-                    tags[tag] = tagList;
+                    tags[tag] = tagList.slice(0, 8);
                 });
 
                 const newResult : Result = {
@@ -108,9 +108,7 @@ const Home: React.FC = () => {
                     text: document._source.text,
                     type: file_ext
                 }
-
                 results.push(newResult);
-        
             });
             setLoaded(true);
             setResults(results);

--- a/client/pages/Resource.tsx
+++ b/client/pages/Resource.tsx
@@ -1,0 +1,135 @@
+import React, { useEffect, useState } from 'react';
+import ReactDOM from 'react-dom';
+import axios, { AxiosResponse, AxiosError } from 'axios';
+import { Layout, Button, Spin, List, Typography, Tag } from 'antd';
+import { DownloadOutlined } from '@ant-design/icons';
+const { Content, Footer } = Layout;
+import Navbar from "../components/Navbar";
+import SimilarCarousel from "../components/SimilarCarousel";
+
+import {
+  useParams
+} from "react-router-dom";
+
+interface Tags {
+    [propName: string]: string[];
+}
+
+interface TagsMap {
+    [propName: string]: string;
+}
+
+interface Result {
+    id: string;
+    file: string;
+    name: string;
+    tags: Tags;
+    text: string;
+    type: string;
+}
+
+const Resource : React.FC = () => {
+    const [resource, setResource] = useState<null|Result>(null);
+    const [loading, setLoading] = useState(true);
+    let { id } = useParams();
+    const url = `http://localhost:5000/api/resource/${id}`;
+
+    useEffect(() => {
+      const fetchData = async () => {
+        const res = await axios(url);
+        const data = res.data as any;
+        const result = data.hits.hits[0];
+        if (result) {
+          const filename = result._source.path;
+          const file_ext = filename.split(".").slice(-1)[0]
+
+          const tags : Tags = {}
+          Object.keys(result._source.tags).forEach( (tag : string) => {
+              let tagList : string[] = result._source.tags[tag];
+              let tagSet : Set<string> = new Set<string>(tagList);
+              tagList = [...tagSet];
+              tags[tag] = tagList;
+          });
+
+          const newResult : Result = {
+              id: result._id,
+              file: result._source.path,
+              name: result._source.name,
+              tags: tags,
+              text: result._source.text,
+              type: file_ext
+          }
+          setResource(newResult);
+          setLoading(false);
+        }
+        else {
+          setResource(null);
+        }
+      };
+      fetchData();
+    }, []);
+
+    const renderTitle = () => {
+      return (
+        resource && resource.name && <h1>{resource.name}</h1>
+      )
+    }
+    const renderTagsItem = (tagName: string, color: string) => {
+        const tagsList = resource && resource.tags && resource.tags[tagName] ? resource.tags[tagName] : [];
+        const tags: { text: string; color: string; }[] = [];
+        tagsList.forEach(tag => {
+          tags.push({
+            "text": tag,
+            "color": color
+          });
+        });
+        return (
+          tags.map(
+            (tag, index) => (
+              <Tag key={index} color={tag.color} style={{margin: "5px !important"}}>{tag.text}</Tag>
+            )
+          )
+        );
+    }
+
+    const renderTags = () => {
+      const tagsToShow = ["locations", "people", "orgs"];
+      const colorMap: TagsMap = {
+        "locations": "magenta",
+        "orgs": "orange",
+        "groups": "green",
+        "time": "geekblue",
+        "people": "purple",
+      };
+      return (
+        tagsToShow.map(
+          tag => (
+            <List.Item key={tag}>
+              <List.Item.Meta title={tag.toUpperCase()} description={renderTagsItem(tag, colorMap[tag])} />
+            </List.Item>
+          )
+        )
+      );
+    }
+
+    return (
+      <Layout>
+          <Navbar></Navbar>
+          <Content className="site-layout" style={{ padding: '50px', paddingBottom: 0, marginTop: 64 }}>
+            <div className="site-layout-content" style={{ background: "#fff", padding: 24 }}>
+              {renderTitle()}
+              <Button type="primary" size="large" icon={<DownloadOutlined />}>Download</Button>
+              <h3 style={{ marginTop: 16, marginBottom: 8 }}>Document Tags</h3>
+              <List bordered>
+                {renderTags()}
+              </List>
+              <h3 style={{ marginTop: 16, marginBottom: 8 }}>Similar Resources</h3>
+              <SimilarCarousel/>
+            </div>
+          </Content>
+          <Footer style={{ textAlign: 'center' }}>The Hoeffler Files</Footer>
+      </Layout>
+    );
+}
+
+export default Resource;

--- a/client/pages/Resource.tsx
+++ b/client/pages/Resource.tsx
@@ -6,10 +6,12 @@ import { DownloadOutlined } from '@ant-design/icons';
 const { Content, Footer } = Layout;
 import Navbar from "../components/Navbar";
 import SimilarCarousel from "../components/SimilarCarousel";
+import { Redirect } from 'react-router-dom';
 
 import {
   useParams
 } from "react-router-dom";
+import PageNotFound from './PageNotFound';
 
 interface Tags {
     [propName: string]: string[];
@@ -32,7 +34,7 @@ const Resource : React.FC = () => {
     const [resource, setResource] = useState<null|Result>(null);
     const [loading, setLoading] = useState(true);
     let { id } = useParams();
-    const url = `http://localhost:5000/api/resource/${id}`;
+    const url = `/api/resource/${id}`;
 
     useEffect(() => {
       const fetchData = async () => {
@@ -57,12 +59,14 @@ const Resource : React.FC = () => {
               name: result._source.name,
               tags: tags,
               text: result._source.text,
-              type: file_ext
+              type: file_ext,
           }
+          document.title = newResult.name;
           setResource(newResult);
           setLoading(false);
         }
         else {
+          setLoading(false);
           setResource(null);
         }
       };
@@ -112,13 +116,17 @@ const Resource : React.FC = () => {
       );
     }
 
+    if(resource == null && !loading){
+      return <PageNotFound></PageNotFound>
+    }
+
     return (
       <Layout>
           <Navbar></Navbar>
           <Content className="site-layout" style={{ padding: '50px', paddingBottom: 0, marginTop: 64 }}>
             <div className="site-layout-content" style={{ background: "#fff", padding: 24 }}>
               {renderTitle()}
-              <Button type="primary" size="large" icon={<DownloadOutlined />}>Download</Button>
+              <Button type="primary" size="large" href = {`https://princeton-gerrymandering.s3.amazonaws.com/${resource && resource.file}`} icon={<DownloadOutlined />}>Download</Button>
               <h3 style={{ marginTop: 16, marginBottom: 8 }}>Document Tags</h3>
               <List bordered>
                 {renderTags()}


### PR DESCRIPTION
Results page looks like this now!

When you click on a search result, it now brings you to the resource page for that result. The page makes an API call and displays tags for the resource. There is also now a UI for similar resources, although no API call because we don't have semantic search working yet. 

I also fixed the filtering bug that appeared with one filter.

This is how the resource page looks now:
<img width="1309" alt="Screen Shot 2020-04-18 at 5 54 47 AM" src="https://user-images.githubusercontent.com/32247313/79634624-9d46c000-8139-11ea-84cc-1c2ec2047e44.png">
