### PR TITLE
file viewer for PDF, Word, and Excel with interface fixes

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -1,11 +1,13 @@
 from flask import Blueprint, request
 from elasticsearch import Elasticsearch
 import certifi
+import json
 
+with open('./config/config.json') as f:
+    config = json.load(f)
 
 api = Blueprint('api', __name__,)
-es = Elasticsearch(['https://search-princeton-gerrymandering-tdoxp3nyeow6asnjm3rufdjf7y.us-east-1.es.amazonaws.com/'], use_ssl=True, ca_certs=certifi.where())
-
+es = Elasticsearch([config["ELASTICSEARCH_URL"]], use_ssl=True, ca_certs=certifi.where())
 
 @api.route("/search", methods = ["GET", "POST"])
 def api_index():
@@ -17,62 +19,22 @@ def api_index():
     for filter in req['filters']:
         if req['isOr']:
             if filter['filter'] == "contains":
-                print({field : filter['value']})
-                new_filter = {
-                    "bool": {
-                        "must": {
-                            "match": {
-                                "tags.%s" % filter['attribute'] : filter['value']
-                            }
-                        }
-                    }
-                }
-                or_filters.append(new_filter)
+                or_filters.append(or_contains_filter(filter))
             elif filter['filter'] == "contains_not":
-                new_filter = {
-                    "bool": {
-                        "must_not": {
-                            "match": {
-                                "tags.%s" % filter['attribute']: filter['value']
-                            }
-                        }
-                    }
-                }
-                or_filters.append(new_filter)
+                or_filters.append(or_not_contains_filter(filter))
             else:
                 print("Unsupported filter type %s" % filter['filter'])
 
 
         if not req['isOr']:
             if filter['filter'] == "contains":
-                new_filter = { "match": {
-                    "tags.%s" % filter['attribute'] : filter['value']
-                }}
-                and_filters.append(new_filter)
+                and_filters.append(and_filter(filter))
             elif filter['filter'] == "contains_not":
-                new_filter = { "match": {
-                    "tags.%s" % filter['attribute'] : filter['value']
-                }}
-                and_not_filters.append(new_filter)
+                and_not_filters.append(and_filter(filter))
             else:
                 print("Unsupported filter type %s" % filter['filter'])
 
-    query = {
-        "query": {
-            "bool": {
-                "must": { "simple_query_string": {
-                    "query": req['query']
-                }},
-                "filter": and_filters,
-                "must_not": and_not_filters,
-                "should": or_filters,
-                "minimum_should_match": 0 if len(or_filters) == 0 else 1
-            },
-        },
-        "size": req['pageSize'],
-        "from": req['pageSize'] * (req['page'] - 1)
-    }
-    print(query)
+    query = generate_query(req, and_filters, and_not_filters, or_filters)
     res = es.search(index="pgp", body=query)
     return res
 
@@ -88,3 +50,49 @@ def resource(id):
     }
     res = es.search(index="pgp", body=query)
     return res
+
+def or_contains_filter(filter):
+    return {
+        "bool": {
+            "must": {
+                "match": {
+                    "tags.%s" % filter['attribute'] : filter['value']
+                }
+            }
+        }
+    }
+
+def or_not_contains_filter(filter):
+    return {
+        "bool": {
+            "must_not": {
+                "match": {
+                    "tags.%s" % filter['attribute']: filter['value']
+                }
+            }
+        }
+    }
+
+def and_filter(filter):
+    return {
+        "match": {
+            "tags.%s" % filter['attribute'] : filter['value']
+        }
+    }
+
+def generate_query(req, and_filters, and_not_filters, or_filters):
+    return {
+        "query": {
+            "bool": {
+                "must": { "simple_query_string": {
+                    "query": req['query']
+                }},
+                "filter": and_filters,
+                "must_not": and_not_filters,
+                "should": or_filters,
+                "minimum_should_match": 0 if len(or_filters) == 0 else 1
+            },
+        },
+        "size": req['pageSize'],
+        "from": req['pageSize'] * (req['page'] - 1)
+    }

--- a/api/main.py
+++ b/api/main.py
@@ -5,7 +5,9 @@ import os
 
 app = Flask(__name__, static_folder='../client/dist', static_url_path='/static/')
 CORS(app)
+
 app.register_blueprint(api, url_prefix = "/api")
+
 
 @app.route('/', defaults={'upath': ''})
 @app.route('/<path:upath>')

--- a/client/components/FileViewer.tsx
+++ b/client/components/FileViewer.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import ReactDOM from 'react-dom'
+
+interface FileViewerProps {
+    type?: string;
+    link: string;
+};
+
+
+const FileViewer: React.FC<FileViewerProps> = ({ type, link }: FileViewerProps) => {
+    const microsoftPath = `https://view.officeapps.live.com/op/embed.aspx?src=${link}`;
+    const viewer = (type == "xlsx" || type == "xlsm")
+    ? (<iframe src={microsoftPath} width='100%' height='720px'/>)
+    : (type == "doc" || type == "docx")
+    ? (<iframe src={microsoftPath} width='100%' height='720px'/>)
+    : (type == "pdf")
+    ? (<embed src={link} type="application/pdf" width="100%" height="720px" />)
+    : null;
+
+    if (viewer) {
+      return (
+        <React.Fragment>
+          <h3 style={{ marginTop: 16, marginBottom: 8 }}>File Preview</h3>
+          {viewer}
+        </React.Fragment>
+      );
+    }
+    return null;
+}
+
+export default FileViewer

--- a/client/components/FileViewer.tsx
+++ b/client/components/FileViewer.tsx
@@ -12,7 +12,7 @@ const FileViewer: React.FC<FileViewerProps> = ({ type, link }: FileViewerProps) 
     const viewer = (type == "xlsx" || type == "xlsm")
     ? (<iframe src={microsoftPath} width='100%' height='540px'/>)
     : (type == "doc" || type == "docx")
-    ? (<iframe src={microsoftPath} width='100%' height='540px'/>)
+    ? (<iframe src={microsoftPath} width='100%' height='720px'/>)
     : (type == "pdf")
     ? (<embed src={link} type="application/pdf" width="100%" height="720px" />)
     : null;

--- a/client/components/FileViewer.tsx
+++ b/client/components/FileViewer.tsx
@@ -10,9 +10,9 @@ interface FileViewerProps {
 const FileViewer: React.FC<FileViewerProps> = ({ type, link }: FileViewerProps) => {
     const microsoftPath = `https://view.officeapps.live.com/op/embed.aspx?src=${link}`;
     const viewer = (type == "xlsx" || type == "xlsm")
-    ? (<iframe src={microsoftPath} width='100%' height='720px'/>)
+    ? (<iframe src={microsoftPath} width='100%' height='540px'/>)
     : (type == "doc" || type == "docx")
-    ? (<iframe src={microsoftPath} width='100%' height='720px'/>)
+    ? (<iframe src={microsoftPath} width='100%' height='540px'/>)
     : (type == "pdf")
     ? (<embed src={link} type="application/pdf" width="100%" height="720px" />)
     : null;
@@ -20,7 +20,6 @@ const FileViewer: React.FC<FileViewerProps> = ({ type, link }: FileViewerProps) 
     if (viewer) {
       return (
         <React.Fragment>
-          <h3 style={{ marginTop: 16, marginBottom: 8 }}>File Preview</h3>
           {viewer}
         </React.Fragment>
       );

--- a/client/components/FilterModal.tsx
+++ b/client/components/FilterModal.tsx
@@ -9,14 +9,7 @@ import SubMenu from 'antd/lib/menu/SubMenu';
 
 import useWindowSize from "../util/useWindowSize";
 import { Link } from 'react-router-dom';
-
-interface Filter {
-    attribute: string;
-    filter: string;
-    value: string;
-    id: number;
-    [propName: string] :any;
-};
+import { Filter } from "../types/interfaces"
 
 interface FilterModalProps {
     onClose: () => void;

--- a/client/components/FilterRow.tsx
+++ b/client/components/FilterRow.tsx
@@ -69,7 +69,7 @@ const FilterRow: React.FC<FilterRowProps> = ({ id, index, deleteRow, updateRow, 
     }
 
     return (
-      <Space style={{ width: '100%', marginBottom:8}}>
+      <Space style={{ width: '100%', marginBottom: 8 }}>
         {renderAndOr()}
         <Select
           showSearch

--- a/client/components/SearchResultsItem.tsx
+++ b/client/components/SearchResultsItem.tsx
@@ -3,23 +3,7 @@ import ReactDOM from 'react-dom'
 import { List, Avatar, Tag } from 'antd';
 import SearchResultsIcon from "../components/SearchResultsIcon";
 import '../css/SearchResultsItem.css';
-
-interface Tags {
-    [propName: string]: string[];
-}
-
-interface TagsMap {
-    [propName: string]: string;
-}
-
-interface Result {
-    id: string;
-    file: string;
-    name: string;
-    tags: Tags;
-    text: string;
-    type: string;
-}
+import { Result, Tags, TagsMap } from "../types/interfaces"
 
 interface SearchResultsItemProps {
     item: Result;

--- a/client/components/SearchResultsList.tsx
+++ b/client/components/SearchResultsList.tsx
@@ -2,19 +2,7 @@ import React, { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom'
 import { List, Spin, Pagination } from 'antd';
 import SearchResultsItem from "../components/SearchResultsItem";
-
-interface Tags {
-    [propName: string]: string[];
-}
-
-interface Result {
-    id: string;
-    file: string;
-    name: string;
-    tags: Tags;
-    text: string;
-    type: string;
-}
+import { Result, Tags } from "../types/interfaces"
 
 interface SearchResultsListProps {
     results?: Result[]

--- a/client/components/SimilarCarousel.tsx
+++ b/client/components/SimilarCarousel.tsx
@@ -4,19 +4,7 @@ import { Carousel, Button } from 'antd';
 import SimilarCarouselItem from "../components/SimilarCarouselItem";
 import '../css/SimilarCarousel.css';
 import { LeftOutlined, RightOutlined } from '@ant-design/icons';
-
-interface Tags {
-    [propName: string]: string[];
-}
-
-interface Result {
-    id: string;
-    file: string;
-    name: string;
-    tags: Tags;
-    text: string;
-    type: string;
-}
+import { Result, Tags } from "../types/interfaces"
 
 const SimilarCarousel: React.FC = () => {
 

--- a/client/components/SimilarCarouselItem.tsx
+++ b/client/components/SimilarCarouselItem.tsx
@@ -3,19 +3,8 @@ import ReactDOM from 'react-dom';
 import Link from "react-router";
 import { Carousel, Card, Avatar } from 'antd';
 import SearchResultsIcon from "../components/SearchResultsIcon";
+import { Result, Tags } from "../types/interfaces"
 
-interface Tags {
-    [propName: string]: string[];
-}
-
-interface Result {
-    id: string;
-    file: string;
-    name: string;
-    tags: Tags;
-    text: string;
-    type: string;
-}
 
 interface SimilarCarouselItemProps {
     resource: Result

--- a/client/pages/Home.tsx
+++ b/client/pages/Home.tsx
@@ -11,25 +11,7 @@ import Navbar from "../components/Navbar";
 import FilterModal from "../components/FilterModal";
 import SearchResultsList from "../components/SearchResultsList";
 import Banner from "../assets/banner.svg";
-
-interface Filter {
-    attribute: string;
-    filter: string;
-    value: string;
-}
-
-interface Tags {
-    [propName: string]: string[];
-}
-
-interface Result {
-    id: string;
-    file: string;
-    name: string;
-    tags: Tags;
-    text: string;
-    type: string;
-}
+import { Result, Tags, Filter } from "../types/interfaces.d.ts"
 
 interface PostQuery {
     query: string;
@@ -38,6 +20,7 @@ interface PostQuery {
     page: number;
     pageSize: number;
 }
+
 
 const Home: React.FC = () => {
     document.title = "The Hofeller Files"
@@ -53,23 +36,6 @@ const Home: React.FC = () => {
     const [totalResults, setTotalResults] = useState(0);
     const [pageSize, setPageSize] = useState(5);
     const [page, setPage] = useState(1)
-
-    // const listData = [];
-    // for (let i = 0; i < 11; i++) {
-    //   listData.push({
-    //     id: i.toString(),
-    //     file: 'test-data/2002 Districts 2010.xlsx',
-    //     name: "2002 Districts 2010.xlsx",
-    //     tags: {
-    //       "locations": ["Arizona", "Bushwick", "California"],
-    //       "orgs": ["RNC", "GOP", "DNC"],
-    //       "groups": ["Latinos", "Asians"],
-    //       "time": ["2002", "2020"]
-    //     },
-    //     text: "Ant Design, a design language for background applications, is refined by Ant UED Team.",
-    //     type: "xlsx"
-    //   });
-    // }
 
     const search = (values : any, page_ : number, pageSize_ : number) => {
         setLoaded(false);

--- a/client/pages/Resource.tsx
+++ b/client/pages/Resource.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 import axios, { AxiosResponse, AxiosError } from 'axios';
-import { Layout, Button, Spin, List, Typography, Tag } from 'antd';
-import { DownloadOutlined } from '@ant-design/icons';
+import { Layout, Button, Spin, List, Typography, Tag, Collapse, PageHeader, Divider } from 'antd';
+import { DownloadOutlined, UpOutlined, DownOutlined, CaretRightOutlined } from '@ant-design/icons';
 const { Content, Footer } = Layout;
 import Navbar from "../components/Navbar";
 import SimilarCarousel from "../components/SimilarCarousel";
@@ -11,135 +11,150 @@ import { Redirect } from 'react-router-dom';
 import { Result, Tags, TagsMap } from "../types/interfaces"
 
 import {
-  useParams
+    useParams
 } from "react-router-dom";
 import PageNotFound from './PageNotFound';
 
 
-const Resource : React.FC = () => {
-    const [resource, setResource] = useState<undefined|Result>(undefined);
+const Resource: React.FC = () => {
+    const [resource, setResource] = useState<undefined | Result>(undefined);
     const [loading, setLoading] = useState(true);
+
     let { id } = useParams();
     const url = `/api/resource/${id}`;
 
     useEffect(() => {
-      const fetchData = async () => {
-        const res = await axios(url);
-        const data = res.data as any;
-        const result = data.hits.hits[0];
-        if (result) {
-          const filename = result._source.path;
-          const file_ext = filename.split(".").slice(-1)[0]
+        const fetchData = async () => {
+            const res = await axios(url);
+            const data = res.data as any;
+            const result = data.hits.hits[0];
+            if (result) {
+                const filename = result._source.path;
+                const file_ext = filename.split(".").slice(-1)[0]
 
-          const tags : Tags = {}
-          Object.keys(result._source.tags).forEach( (tag : string) => {
-              let tagList : string[] = result._source.tags[tag];
-              let tagSet : Set<string> = new Set<string>(tagList);
-              tagList = [...tagSet];
-              tags[tag] = tagList;
-          });
+                const tags: Tags = {}
+                Object.keys(result._source.tags).forEach((tag: string) => {
+                    let tagList: string[] = result._source.tags[tag];
+                    let tagSet: Set<string> = new Set<string>(tagList);
+                    tagList = [...tagSet];
+                    tags[tag] = tagList;
+                });
 
-          const newResult : Result = {
-              id: result._id,
-              file: result._source.path,
-              name: result._source.name,
-              tags: tags,
-              text: result._source.text,
-              type: file_ext,
-          }
-          document.title = newResult.name;
-          setResource(newResult);
-          setLoading(false);
-        }
-        else {
-          setLoading(false);
-          setResource(undefined);
-        }
-      };
-      fetchData();
+                const newResult: Result = {
+                    id: result._id,
+                    file: result._source.path,
+                    name: result._source.name,
+                    tags: tags,
+                    text: result._source.text,
+                    type: file_ext,
+                }
+                document.title = newResult.name;
+                setResource(newResult);
+                setLoading(false);
+            }
+            else {
+                setLoading(false);
+                setResource(undefined);
+            }
+        };
+        fetchData();
     }, []);
 
-    const renderTitle = () => {
-      return (
-        resource && resource.name && <h1>{resource.name}</h1>
-      )
+    const renderHeader = () => {
+        return (
+            resource && resource.name && 
+                <PageHeader onBack = { () => history.back() }style = {{ padding: 0 }} title = {resource.name} extra = {[
+                    <Button type="primary" size="large" href={`https://princeton-gerrymandering.s3.amazonaws.com/${resource && resource.file}`} icon={<DownloadOutlined />}>Download</Button>
+                ]}></PageHeader>
+        )
     }
 
     const renderTags = (tagName: string, color: string) => {
         const tagsList = resource && resource.tags && resource.tags[tagName] ? resource.tags[tagName] : [];
         const tags: { text: string; color: string; }[] = [];
         tagsList.forEach(tag => {
-          tags.push({
-            "text": tag,
-            "color": color
-          });
+            tags.push({
+                "text": tag,
+                "color": color
+            });
         });
         return (
-          tags.map(
-            (tag, index) => (
-              <Tag key={index} color={tag.color} style={{margin: "5px !important"}}>{tag.text}</Tag>
+            tags.map(
+                (tag, index) => (
+                    <Tag key={index} color={tag.color} style={{ margin: "5px !important" }}>{tag.text}</Tag>
+                )
             )
-          )
         );
     }
 
     const renderTagsListItem = (tag: string) => {
-      const colorMap: TagsMap = {
-        "locations": "magenta",
-        "orgs": "orange",
-        "groups": "green",
-        "time": "geekblue",
-        "people": "purple",
-      };
-      if (resource && resource.tags && resource.tags[tag] && resource.tags[tag].length > 0) {
-        return (<List.Item key={tag}>
-          <List.Item.Meta title={tag[0].toUpperCase() + tag.slice(1)} description={renderTags(tag, colorMap[tag])} />
-        </List.Item>)
-      }
-      return null;
+        const colorMap: TagsMap = {
+            "locations": "magenta",
+            "orgs": "orange",
+            "groups": "green",
+            "time": "geekblue",
+            "people": "purple",
+        };
+
+        const displayTags : TagsMap = {
+            "locations": "Locations",
+            "orgs": "Organizations",
+            "groups": "Groups",
+            "time": "Dates and Times",
+            "people": "People"
+        }
+
+        if (resource && resource.tags && resource.tags[tag] && resource.tags[tag].length > 0) {
+            return (
+                <Collapse.Panel header = {displayTags[tag]} key = {tag}>
+                    {renderTags(tag, colorMap[tag])}
+                </Collapse.Panel>
+            )
+        }
+        return null;
     }
 
     const renderTagsList = () => {
-      const tagsToShow = ["locations", "people", "orgs"];
-      const isFalsy = (elt: any) => elt.length == 0;
-      const entries = resource && resource.tags && Object.entries(resource.tags) ? Object.entries(resource.tags).map(x => x[1]) : [];
-      const noTags = entries.every(isFalsy);
-      if (noTags) {
-        return null;
-      }
-      return (
-        <React.Fragment>
-          <h3 style={{ marginTop: 16, marginBottom: 8 }}>Document Tags</h3>
-          <List bordered>
-            {tagsToShow.map(
-              tag => (
-                renderTagsListItem(tag)
-              )
-            )}
-          </List>
-        </React.Fragment>
-      );
+        const tagsToShow = ["locations", "people", "orgs"];
+        const isFalsy = (elt: any) => elt.length == 0;
+        const entries = resource && resource.tags && Object.entries(resource.tags) ? Object.entries(resource.tags).map(x => x[1]) : [];
+        const noTags = entries.every(isFalsy);
+        if (noTags) {
+            return null;
+        }
+        return (
+            <React.Fragment>
+                <Collapse bordered = {true} expandIcon={({ isActive }) => <CaretRightOutlined rotate={isActive ? 90 : 0} />}>
+                    {tagsToShow.map(
+                        tag => (
+                            renderTagsListItem(tag)
+                        )
+                    )}
+                </Collapse>
+            </React.Fragment>
+        );
     }
 
-    if (resource == null && !loading){
-      return <PageNotFound></PageNotFound>
+    if (resource == null && !loading) {
+        return <PageNotFound></PageNotFound>
     }
 
     return (
-      <Layout>
-          <Navbar></Navbar>
-          <Content className="site-layout" style={{ padding: '50px', paddingBottom: 0, marginTop: 64 }}>
-            <div className="site-layout-content" style={{ background: "#fff", padding: 24 }}>
-              {renderTitle()}
-              <Button type="primary" size="large" href = {`https://princeton-gerrymandering.s3.amazonaws.com/${resource && resource.file}`} icon={<DownloadOutlined />}>Download</Button>
-                {renderTagsList()}
-              <FileViewer type={resource && resource.type} link={`https://princeton-gerrymandering.s3.amazonaws.com/${resource && resource.file}`}/>
-              <h3 style={{ marginTop: 16, marginBottom: 8 }}>Similar Resources</h3>
-              <SimilarCarousel/>
-            </div>
-          </Content>
-          <Footer style={{ textAlign: 'center' }}>The Hoeffler Files</Footer>
-      </Layout>
+        <Layout>
+            <Navbar></Navbar>
+            <Content className="site-layout" style={{ padding: '50px', paddingBottom: 0, marginTop: 64 }}>
+                <div className="site-layout-content" style={{ background: "#fff", padding: 50 }}>
+                    {renderHeader()}
+                    <Divider style = {{ fontSize: 18, marginTop: 40 }}>Document Tags</Divider>
+                        {renderTagsList()}
+                    <Divider style = {{ fontSize: 18, marginTop: 40 }}>File Preview</Divider>
+                    <FileViewer type={resource && resource.type} link={`https://princeton-gerrymandering.s3.amazonaws.com/${resource && resource.file}`} />
+                    <Divider style = {{ fontSize: 18, marginTop: 40 }} >Similar Files</Divider>
+                    <SimilarCarousel />
+                </div>
+            </Content>
+            <Footer style={{ textAlign: 'center' }}>The Hoeffler Files</Footer>
+        </Layout>
     );
 }
 

--- a/client/types/interfaces.d.ts
+++ b/client/types/interfaces.d.ts
@@ -1,0 +1,24 @@
+export interface Tags {
+    [propName: string]: string[];
+};
+
+export interface TagsMap {
+    [propName: string]: string;
+}
+
+export interface Result {
+    id: string;
+    file: string;
+    name: string;
+    tags: Tags;
+    text: string;
+    type: string;
+};
+
+export interface Filter {
+    attribute: string;
+    filter: string;
+    value: string;
+    id: number;
+    [propName: string]: any;
+}

--- a/config/config.json
+++ b/config/config.json
@@ -1,0 +1,3 @@
+{
+    "ELASTICSEARCH_URL": "PUT_HERE"
+}

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "dayjs": "^1.8.24",
     "dotenv": "^8.2.0",
     "less": "^3.11.1",
+    "pdf-viewer-reactjs": "^2.0.6",
     "pycollections": "^0.9.0",
     "react": "^16.13.0",
     "react-dom": "^16.13.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "forceConsistentCasingInFileNames": true,
     "module": "esnext",
     "moduleResolution": "node",
+    "noImplicitAny": false,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react",


### PR DESCRIPTION
- File viewer for PDF, Word, and Excel documents
- Extracted common interfaces into /client/types/interfaces.d.ts
- Only show tags, fileviewer on resource page when that is available for document. 

TODO: 
- Resolve console warnings for Word and Excel FileViewer related to Microsoft API.
- Display other file types.