### PR TITLE
suggestion front end and gitignre

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,5 @@ package-lock.json
 __pycache__
 api/.flaskenv
 api/venv
-
+api/config
 client/dist/*-bundle.js

--- a/api/blueprints/api.py
+++ b/api/blueprints/api.py
@@ -87,6 +87,17 @@ def resource(id):
     return res
 
 
+@api.route("/suggest/<string:id>", methods=["GET"])
+@login_required
+def suggest(id):
+    recs_results = []
+    recomendations = ["yLgaL3MB0Xqz4htPkZFX", "-HJ-fnMBfx90TkXxN87_", "T3K2dHMBfx90TkXx78nu", "Rrh6MHMB0Xqz4htPypUV", "gLjtLnMB0Xqz4htPsJCP", "AnKifnMBfx90TkXx-c-k", "LLg5NnMB0Xqz4htPj7Ds"]
+    for rec in recomendations:
+        recData = resource(rec)
+        if(recData):
+            recs_results.append(json.dumps(recData))      
+    return jsonify({'recs' : recs_results}), 200
+
 @api.route("/tags/add", methods = ["POST"])
 @login_required
 def add_tags():

--- a/client/components/SimilarCarousel.tsx
+++ b/client/components/SimilarCarousel.tsx
@@ -6,25 +6,14 @@ import '../css/SimilarCarousel.css';
 import { LeftOutlined, RightOutlined } from '@ant-design/icons';
 import { Result, Tags } from "../types/interfaces"
 
-const SimilarCarousel: React.FC = () => {
+interface SimilarCarouselSuggestions {
+  suggestions: Result[];
+  refresh: () => void;
+}
 
-    const listData : Result[] = [];
-    for (let i = 0; i < 11; i++) {
-      listData.push({
-        id: i.toString(),
-        file: 'test-data/2002 Districts 2010.xlsx',
-        name: "2002 Districts 2010.xlsx",
-        tags: {
-          "locations": ["Arizona", "Bushwick", "California"],
-          "orgs": ["RNC", "GOP", "DNC"],
-          "groups": ["Latinos", "Asians"],
-          "time": ["2002", "2020"]
-        },
-        text: "Ant Design, a design language for background applications, is refined by Ant UED Team.",
-        type: "xlsx"
-      });
-    }
-
+const SimilarCarousel: React.FC<SimilarCarouselSuggestions> = ({suggestions,  refresh}) => {
+    const listData : Result[] = suggestions;
+    
     function NextArrow(props:any) {
       const { className, style, onClick } = props;
       return (

--- a/client/components/SimilarCarouselItem.tsx
+++ b/client/components/SimilarCarouselItem.tsx
@@ -14,13 +14,16 @@ const SimilarCarouselItem: React.FC<SimilarCarouselItemProps> = ({ resource }) =
 
     const avatarIcon = <SearchResultsIcon filetype={resource.type} />;
 
+    var str = resource.text;
+    if(str.length > 10) str = str.substring(0,30);
+
     return (
       <div>
         <Card>
           <Card.Meta
             avatar={<Avatar size={64} style={{ textAlign: "center" }} shape="square" icon={avatarIcon} />}
             title={<a href={`${resource.id}`}>{resource.name}</a>}
-            description="This is the description"
+            description={str}
           />
         </Card>
       </div>


### PR DESCRIPTION
Built out backend/minor front end changes so when a resource is loaded it loads suggestions from ID 

- Added /suggest/id route to api.py which takes an ID and returns a json with relevant file suggestions 

- Added loadSuggestions() to Resource.tsx which makes the request to the backed with the file and builds the list of Result objects 

- Modified the description of the SimilarCarouselItemProps to contain the first 25 characters of the text of the suggested document 

- Added api/config to gitignore